### PR TITLE
Pass re.VERBOSE explicitly

### DIFF
--- a/yaql/language/factory.py
+++ b/yaql/language/factory.py
@@ -237,7 +237,7 @@ class YaqlFactory(object):
         names = self._name_generator()
         operators = self._build_operator_table(names)
         lexer_rules = self._create_lexer(operators)
-        ply_lexer = lex.lex(object=lexer_rules, reflags=re.UNICODE)
+        ply_lexer = lex.lex(object=lexer_rules, reflags=re.UNICODE | re.VERBOSE)
         ply_parser = yacc.yacc(
             module=self._create_parser(lexer_rules, operators),
             debug=False if not options else options.get('yaql.debug', False),


### PR DESCRIPTION
ply has just made this flag optional which broke regex
matching completely.