### PR TITLE
Add support for python 3.9

### DIFF
--- a/yaql/language/utils.py
+++ b/yaql/language/utils.py
@@ -34,16 +34,16 @@ NO_VALUE = create_marker('<NoValue>')
 
 
 def is_iterator(obj):
-    return isinstance(obj, collections.Iterator)
+    return isinstance(obj, collections.abc.Iterator)
 
 
 def is_iterable(obj):
-    return isinstance(obj, collections.Iterable) and not isinstance(
+    return isinstance(obj, collections.abc.Iterable) and not isinstance(
         obj, six.string_types + (MappingType,))
 
 
 def is_sequence(obj):
-    return isinstance(obj, collections.Sequence) and not isinstance(
+    return isinstance(obj, collections.abc.Sequence) and not isinstance(
         obj, six.string_types)
 
 
@@ -53,14 +53,14 @@ def is_mutable(obj):
                             collections.MutableMapping))
 
 
-SequenceType = collections.Sequence
-MutableSequenceType = collections.MutableSequence
-SetType = collections.Set
-MutableSetType = collections.MutableSet
-MappingType = collections.Mapping
-MutableMappingType = collections.MutableMapping
-IterableType = collections.Iterable
-IteratorType = collections.Iterator
+SequenceType = collections.abc.Sequence
+MutableSequenceType = collections.abc.MutableSequence
+SetType = collections.abc.Set
+MutableSetType = collections.abc.MutableSet
+MappingType = collections.abc.Mapping
+MutableMappingType = collections.abc.MutableMapping
+IterableType = collections.abc.Iterable
+IteratorType = collections.abc.Iterator
 QueueType = collections.deque
 
 
@@ -85,7 +85,7 @@ def convert_input_data(obj, rec=None):
 def convert_output_data(obj, limit_func, engine, rec=None):
     if rec is None:
         rec = convert_output_data
-    if isinstance(obj, collections.Mapping):
+    if isinstance(obj, collections.abc.Mapping):
         result = {}
         for key, value in limit_func(six.iteritems(obj)):
             result[rec(key, limit_func, engine, rec)] = rec(
@@ -119,7 +119,7 @@ class MappingRule(object):
         self.destination = destination
 
 
-class FrozenDict(collections.Mapping):
+class FrozenDict(collections.abc.Mapping):
     def __init__(self, *args, **kwargs):
         self._d = dict(*args, **kwargs)
         self._hash = None

--- a/yaql/language/yaqltypes.py
+++ b/yaql/language/yaqltypes.py
@@ -189,7 +189,7 @@ class Iterable(PythonType):
 
     def __init__(self, validators=None, nullable=False):
         super(Iterable, self).__init__(
-            collections.Iterable, nullable, [
+            collections.abc.Iterable, nullable, [
                 lambda t: not isinstance(t, six.string_types + (
                     utils.MappingType,))] + (validators or []))
 
@@ -221,7 +221,7 @@ class Sequence(PythonType):
 
     def __init__(self, validators=None, nullable=False):
         super(Sequence, self).__init__(
-            collections.Sequence, nullable, [
+            collections.abc.Sequence, nullable, [
                 lambda t: not isinstance(t, six.string_types + (dict,))] + (
                     validators or []))
 


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it stopped working. This also makes the package incompatible with 2.7, but it's needed to work with newer versions.