### PR TITLE
Fix localtz() function

### DIFF
--- a/yaql/standard_library/date_time.py
+++ b/yaql/standard_library/date_time.py
@@ -322,7 +322,7 @@ def localtz():
         yaql> localtz().hours
         3.0
     """
-    if python_time.daylight:
+    if python_time.localtime().tm_isdst:
         return TIMESPAN_TYPE(seconds=-python_time.altzone)
     else:
         return TIMESPAN_TYPE(seconds=-python_time.timezone)


### PR DESCRIPTION
Hi, i came across problem with localtz() function. Per your documentation I understand localtz() function returns timezone information by returning offset seconds to UTC TZ.

But in code there's bad if (line 325) - there is used parameter "time.daylight" which does NOT indicate whether there is currently DST. It only (per multiple issues found on internet) indicates whether the TZ does or does not have DST.

You should better use time.localtime().tm_isdst which really indicates if DST is active or not.

- We have usecase where we use yaql localtz() to get current time: `now(offset=>localtz()).format("%Y-%m-%d %H:%M")`
-- But this approach is not correct now because it now return DST time (so +1hour to real time).

Issue i reffer to: https://bugs.python.org/issue7229